### PR TITLE
Make client and server acceptors asymmetric

### DIFF
--- a/rsocket-core/src/main/java/com/jauntsdn/rsocket/ClientSocketAcceptor.java
+++ b/rsocket-core/src/main/java/com/jauntsdn/rsocket/ClientSocketAcceptor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 - present Maksym Ostroverkhov.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.jauntsdn.rsocket;
+
+/**
+ * {@code RSocket} is a full duplex protocol where a client and server are identical in terms of
+ * both having the capability to initiate requests to their peer. This interface provides the
+ * contract where a client accepts a new {@code RSocket} for sending requests to the peer and
+ * returns a new {@code RSocket} that will be used to accept requests from it's peer.
+ */
+public interface ClientSocketAcceptor {
+
+  /**
+   * Accepts a new {@code RSocket} used to send requests to the peer and returns another {@code
+   * RSocket} that is used for accepting requests from the peer.
+   *
+   * @param setup Setup as sent by the client.
+   * @param sendingSocket RSocket used to send requests to the peer.
+   * @return RSocket to accept requests from the peer.
+   */
+  RSocket accept(ConnectionSetupPayload setup, RSocket sendingSocket);
+}

--- a/rsocket-core/src/main/java/com/jauntsdn/rsocket/ServerSocketAcceptor.java
+++ b/rsocket-core/src/main/java/com/jauntsdn/rsocket/ServerSocketAcceptor.java
@@ -20,21 +20,21 @@ import com.jauntsdn.rsocket.exceptions.SetupException;
 import reactor.core.publisher.Mono;
 
 /**
- * RSocket is a full duplex protocol where a client and server are identical in terms of both having
- * the capability to initiate requests to their peer. This interface provides the contract where a
- * client or server handles the {@code setup} for a new connection and creates a responder {@code
- * RSocket} for accepting requests from the remote peer.
+ * {@code RSocket} is a full duplex protocol where a client and server are identical in terms of
+ * both having the capability to initiate requests to their peer. This interface provides the
+ * contract where a server accepts a new {@code RSocket} for sending requests to the peer and
+ * returns a new {@code RSocket} that will be used to accept requests from it's peer.
  */
-public interface SocketAcceptor {
+public interface ServerSocketAcceptor {
 
   /**
-   * Handle the {@code SETUP} frame for a new connection and create a responder {@code RSocket} for
-   * handling requests from the remote peer.
+   * Accepts a new {@code RSocket} used to send requests to the peer and returns another {@code
+   * RSocket} that is used for accepting requests from the peer.
    *
-   * @param setup the {@code setup} received from a client in a server scenario, or in a client
-   *     scenario this is the setup about to be sent to the server.
-   * @param sendingSocket socket for sending requests to the remote peer.
-   * @return {@code RSocket} to accept requests with.
+   * @param setup Setup as sent by the client.
+   * @param sendingSocket RSocket used to send requests to the peer.
+   * @return Mono signalling error if setup is rejected,otherwise returns RSocket to accept requests
+   *     from the peer.
    * @throws SetupException If the acceptor needs to reject the setup of this socket.
    */
   Mono<RSocket> accept(ConnectionSetupPayload setup, RSocket sendingSocket);

--- a/rsocket-core/src/main/java/com/jauntsdn/rsocket/internal/ServerSetup.java
+++ b/rsocket-core/src/main/java/com/jauntsdn/rsocket/internal/ServerSetup.java
@@ -131,7 +131,7 @@ public interface ServerSetup {
                 .resumableConnection();
         return then.apply(
             new ResumableKeepAliveHandler(connection),
-            new ClientServerInputMultiplexer(connection));
+            new ClientServerInputMultiplexer(connection, false));
       } else {
         return then.apply(new DefaultKeepAliveHandler(multiplexer), multiplexer);
       }

--- a/rsocket-core/src/main/java/com/jauntsdn/rsocket/plugins/ClientAcceptorInterceptor.java
+++ b/rsocket-core/src/main/java/com/jauntsdn/rsocket/plugins/ClientAcceptorInterceptor.java
@@ -15,15 +15,15 @@
  */
 package com.jauntsdn.rsocket.plugins;
 
-import com.jauntsdn.rsocket.SocketAcceptor;
+import com.jauntsdn.rsocket.ClientSocketAcceptor;
 import java.util.function.Function;
 
 /**
- * Contract to decorate a {@link SocketAcceptor}, providing access to connection {@code setup}
+ * Contract to decorate a {@link ClientSocketAcceptor}, providing access to connection {@code setup}
  * information and the ability to also decorate the sockets for requesting and responding.
  *
  * <p>This can be used as an alternative to individual requester and responder {@link
  * RSocketInterceptor} plugins.
  */
-public @FunctionalInterface interface SocketAcceptorInterceptor
-    extends Function<SocketAcceptor, SocketAcceptor> {}
+public @FunctionalInterface interface ClientAcceptorInterceptor
+    extends Function<ClientSocketAcceptor, ClientSocketAcceptor> {}

--- a/rsocket-core/src/main/java/com/jauntsdn/rsocket/plugins/DuplexConnectionInterceptor.java
+++ b/rsocket-core/src/main/java/com/jauntsdn/rsocket/plugins/DuplexConnectionInterceptor.java
@@ -17,15 +17,8 @@
 package com.jauntsdn.rsocket.plugins;
 
 import com.jauntsdn.rsocket.DuplexConnection;
-import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /** */
-public @FunctionalInterface interface DuplexConnectionInterceptor
-    extends BiFunction<DuplexConnectionInterceptor.Type, DuplexConnection, DuplexConnection> {
-  enum Type {
-    SETUP,
-    CLIENT,
-    SERVER,
-    SOURCE
-  }
-}
+@FunctionalInterface
+public interface DuplexConnectionInterceptor extends Function<DuplexConnection, DuplexConnection> {}

--- a/rsocket-core/src/main/java/com/jauntsdn/rsocket/plugins/PluginRegistry.java
+++ b/rsocket-core/src/main/java/com/jauntsdn/rsocket/plugins/PluginRegistry.java
@@ -87,10 +87,9 @@ public class PluginRegistry {
     return acceptor;
   }
 
-  public DuplexConnection applyConnection(
-      DuplexConnectionInterceptor.Type type, DuplexConnection connection) {
+  public DuplexConnection applyConnection(DuplexConnection connection) {
     for (DuplexConnectionInterceptor i : connections) {
-      connection = i.apply(type, connection);
+      connection = i.apply(connection);
     }
 
     return connection;

--- a/rsocket-core/src/main/java/com/jauntsdn/rsocket/plugins/PluginRegistry.java
+++ b/rsocket-core/src/main/java/com/jauntsdn/rsocket/plugins/PluginRegistry.java
@@ -16,9 +16,7 @@
 
 package com.jauntsdn.rsocket.plugins;
 
-import com.jauntsdn.rsocket.DuplexConnection;
-import com.jauntsdn.rsocket.RSocket;
-import com.jauntsdn.rsocket.SocketAcceptor;
+import com.jauntsdn.rsocket.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,7 +24,8 @@ public class PluginRegistry {
   private List<DuplexConnectionInterceptor> connections = new ArrayList<>();
   private List<RSocketInterceptor> requesters = new ArrayList<>();
   private List<RSocketInterceptor> responders = new ArrayList<>();
-  private List<SocketAcceptorInterceptor> socketAcceptorInterceptors = new ArrayList<>();
+  private List<ClientAcceptorInterceptor> clientAcceptorInterceptors = new ArrayList<>();
+  private List<ServerAcceptorInterceptor> serverAcceptorInterceptors = new ArrayList<>();
 
   public PluginRegistry() {}
 
@@ -48,8 +47,12 @@ public class PluginRegistry {
     responders.add(interceptor);
   }
 
-  public void addSocketAcceptorPlugin(SocketAcceptorInterceptor interceptor) {
-    socketAcceptorInterceptors.add(interceptor);
+  public void addClientAcceptorPlugin(ClientAcceptorInterceptor interceptor) {
+    clientAcceptorInterceptors.add(interceptor);
+  }
+
+  public void addServerAcceptorPlugin(ServerAcceptorInterceptor interceptor) {
+    serverAcceptorInterceptors.add(interceptor);
   }
 
   public RSocket applyRequester(RSocket rSocket) {
@@ -68,8 +71,16 @@ public class PluginRegistry {
     return rSocket;
   }
 
-  public SocketAcceptor applySocketAcceptorInterceptor(SocketAcceptor acceptor) {
-    for (SocketAcceptorInterceptor i : socketAcceptorInterceptors) {
+  public ClientSocketAcceptor applyClientSocketAcceptor(ClientSocketAcceptor acceptor) {
+    for (ClientAcceptorInterceptor i : clientAcceptorInterceptors) {
+      acceptor = i.apply(acceptor);
+    }
+
+    return acceptor;
+  }
+
+  public ServerSocketAcceptor applyServerSocketAcceptor(ServerSocketAcceptor acceptor) {
+    for (ServerAcceptorInterceptor i : serverAcceptorInterceptors) {
       acceptor = i.apply(acceptor);
     }
 

--- a/rsocket-core/src/main/java/com/jauntsdn/rsocket/plugins/ServerAcceptorInterceptor.java
+++ b/rsocket-core/src/main/java/com/jauntsdn/rsocket/plugins/ServerAcceptorInterceptor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jauntsdn.rsocket.plugins;
+
+import com.jauntsdn.rsocket.ServerSocketAcceptor;
+import java.util.function.Function;
+
+/**
+ * Contract to decorate a {@link ServerSocketAcceptor}, providing access to connection {@code setup}
+ * information and the ability to also decorate the sockets for requesting and responding.
+ *
+ * <p>This can be used as an alternative to individual requester and responder {@link
+ * RSocketInterceptor} plugins.
+ */
+public @FunctionalInterface interface ServerAcceptorInterceptor
+    extends Function<ServerSocketAcceptor, ServerSocketAcceptor> {}

--- a/rsocket-core/src/main/java/com/jauntsdn/rsocket/resume/ClientRSocketSession.java
+++ b/rsocket-core/src/main/java/com/jauntsdn/rsocket/resume/ClientRSocketSession.java
@@ -84,7 +84,7 @@ public class ClientRSocketSession implements RSocketSession<Mono<DuplexConnectio
                                           .doOnNext(v -> logger.debug("Retrying with: {}", v))))
                   .timeout(resumeSessionDuration);
             })
-        .map(ClientServerInputMultiplexer::new)
+        .map(source -> new ClientServerInputMultiplexer(source, true))
         .subscribe(
             multiplexer -> {
               /*reconnect resumable connection*/

--- a/rsocket-core/src/test/java/com/jauntsdn/rsocket/RSocketLeaseTest.java
+++ b/rsocket-core/src/test/java/com/jauntsdn/rsocket/RSocketLeaseTest.java
@@ -33,7 +33,6 @@ import com.jauntsdn.rsocket.keepalive.KeepAliveHandler;
 import com.jauntsdn.rsocket.lease.Lease;
 import com.jauntsdn.rsocket.lease.RequesterLeaseHandler;
 import com.jauntsdn.rsocket.lease.ResponderLeaseHandler;
-import com.jauntsdn.rsocket.plugins.PluginRegistry;
 import com.jauntsdn.rsocket.test.util.TestClientTransport;
 import com.jauntsdn.rsocket.test.util.TestDuplexConnection;
 import com.jauntsdn.rsocket.test.util.TestServerTransport;
@@ -82,8 +81,7 @@ class RSocketLeaseTest {
         new ResponderLeaseHandler.Impl<>(
             byteBufAllocator, stats -> leaseSender, err -> {}, Optional.empty());
 
-    ClientServerInputMultiplexer multiplexer =
-        new ClientServerInputMultiplexer(connection, new PluginRegistry(), true);
+    ClientServerInputMultiplexer multiplexer = new ClientServerInputMultiplexer(connection, true);
     rSocketRequester =
         new LeaseRSocketRequester(
             byteBufAllocator,

--- a/rsocket-core/src/test/java/com/jauntsdn/rsocket/SetupRejectionTest.java
+++ b/rsocket-core/src/test/java/com/jauntsdn/rsocket/SetupRejectionTest.java
@@ -110,7 +110,7 @@ public class SetupRejectionTest {
         .verify(Duration.ofSeconds(5));
   }
 
-  private static class RejectingAcceptor implements SocketAcceptor {
+  private static class RejectingAcceptor implements ServerSocketAcceptor {
     private final String errorMessage;
     private final UnicastProcessor<RSocket> senderRSockets = UnicastProcessor.create();
 

--- a/rsocket-core/src/test/java/com/jauntsdn/rsocket/internal/ClientServerInputMultiplexerTest.java
+++ b/rsocket-core/src/test/java/com/jauntsdn/rsocket/internal/ClientServerInputMultiplexerTest.java
@@ -19,7 +19,6 @@ package com.jauntsdn.rsocket.internal;
 import static org.junit.Assert.assertEquals;
 
 import com.jauntsdn.rsocket.frame.*;
-import com.jauntsdn.rsocket.plugins.PluginRegistry;
 import com.jauntsdn.rsocket.test.util.TestDuplexConnection;
 import com.jauntsdn.rsocket.util.DefaultPayload;
 import io.netty.buffer.ByteBuf;
@@ -38,8 +37,8 @@ public class ClientServerInputMultiplexerTest {
   @Before
   public void setup() {
     source = new TestDuplexConnection();
-    clientMultiplexer = new ClientServerInputMultiplexer(source, new PluginRegistry(), true);
-    serverMultiplexer = new ClientServerInputMultiplexer(source, new PluginRegistry(), false);
+    clientMultiplexer = new ClientServerInputMultiplexer(source, true);
+    serverMultiplexer = new ClientServerInputMultiplexer(source, false);
   }
 
   @Test

--- a/rsocket-metrics/src/main/java/com/jauntsdn/rsocket/micrometer/MicrometerDuplexConnectionInterceptor.java
+++ b/rsocket-metrics/src/main/java/com/jauntsdn/rsocket/micrometer/MicrometerDuplexConnectionInterceptor.java
@@ -17,7 +17,6 @@
 package com.jauntsdn.rsocket.micrometer;
 
 import com.jauntsdn.rsocket.DuplexConnection;
-import com.jauntsdn.rsocket.frame.FrameType;
 import com.jauntsdn.rsocket.plugins.DuplexConnectionInterceptor;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -27,12 +26,6 @@ import java.util.Objects;
 /**
  * An implementation of {@link DuplexConnectionInterceptor} that intercepts frames and gathers
  * Micrometer metrics about them.
- *
- * <p>The metric is called {@code rsocket.frame} and is tagged with {@code connection.type} ({@link
- * DuplexConnectionInterceptor.Type}), {@code frame.type} ({@link FrameType}), and any additional
- * configured tags. {@code rsocket.duplex.connection.close} and {@code
- * rsocket.duplex.connection.dispose} metrics, tagged with {@code connection.type} ({@link
- * DuplexConnectionInterceptor.Type}) and any additional configured tags are also collected.
  *
  * @see <a href="https://micrometer.io">Micrometer</a>
  */
@@ -55,10 +48,9 @@ public final class MicrometerDuplexConnectionInterceptor implements DuplexConnec
   }
 
   @Override
-  public MicrometerDuplexConnection apply(Type connectionType, DuplexConnection delegate) {
-    Objects.requireNonNull(connectionType, "connectionType must not be null");
+  public MicrometerDuplexConnection apply(DuplexConnection delegate) {
     Objects.requireNonNull(delegate, "delegate must not be null");
 
-    return new MicrometerDuplexConnection(connectionType, delegate, meterRegistry, tags);
+    return new MicrometerDuplexConnection(delegate, meterRegistry, tags);
   }
 }

--- a/rsocket-metrics/src/test/java/com/jauntsdn/rsocket/micrometer/MicrometerDuplexConnectionInterceptorTest.java
+++ b/rsocket-metrics/src/test/java/com/jauntsdn/rsocket/micrometer/MicrometerDuplexConnectionInterceptorTest.java
@@ -16,7 +16,6 @@
 
 package com.jauntsdn.rsocket.micrometer;
 
-import static com.jauntsdn.rsocket.plugins.DuplexConnectionInterceptor.Type.CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.mockito.Mockito.RETURNS_SMART_NULLS;
@@ -36,25 +35,15 @@ final class MicrometerDuplexConnectionInterceptorTest {
   @DisplayName("creates MicrometerDuplexConnection")
   @Test
   void apply() {
-    assertThat(new MicrometerDuplexConnectionInterceptor(meterRegistry).apply(CLIENT, delegate))
+    assertThat(new MicrometerDuplexConnectionInterceptor(meterRegistry).apply(delegate))
         .isInstanceOf(MicrometerDuplexConnection.class);
-  }
-
-  @DisplayName("apply throws NullPointerException with null connectionType")
-  @Test
-  void applyNullConnectionType() {
-    assertThatNullPointerException()
-        .isThrownBy(
-            () -> new MicrometerDuplexConnectionInterceptor(meterRegistry).apply(null, delegate))
-        .withMessage("connectionType must not be null");
   }
 
   @DisplayName("apply throws NullPointerException with null delegate")
   @Test
   void applyNullDelegate() {
     assertThatNullPointerException()
-        .isThrownBy(
-            () -> new MicrometerDuplexConnectionInterceptor(meterRegistry).apply(CLIENT, null))
+        .isThrownBy(() -> new MicrometerDuplexConnectionInterceptor(meterRegistry).apply(null))
         .withMessage("delegate must not be null");
   }
 

--- a/rsocket-test/src/main/java/com/jauntsdn/rsocket/test/PingHandler.java
+++ b/rsocket-test/src/main/java/com/jauntsdn/rsocket/test/PingHandler.java
@@ -20,13 +20,13 @@ import com.jauntsdn.rsocket.AbstractRSocket;
 import com.jauntsdn.rsocket.ConnectionSetupPayload;
 import com.jauntsdn.rsocket.Payload;
 import com.jauntsdn.rsocket.RSocket;
-import com.jauntsdn.rsocket.SocketAcceptor;
+import com.jauntsdn.rsocket.ServerSocketAcceptor;
 import com.jauntsdn.rsocket.util.ByteBufPayload;
 import java.util.concurrent.ThreadLocalRandom;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public class PingHandler implements SocketAcceptor {
+public class PingHandler implements ServerSocketAcceptor {
 
   private final Payload pong;
 

--- a/rsocket-transport-netty/src/test/java/com/jauntsdn/rsocket/integration/IntegrationTest.java
+++ b/rsocket-transport-netty/src/test/java/com/jauntsdn/rsocket/integration/IntegrationTest.java
@@ -97,7 +97,7 @@ public class IntegrationTest {
             };
 
     connectionPlugin =
-        (type, connection) -> {
+        connection -> {
           calledFrame = true;
           return connection;
         };

--- a/rsocket-transport-netty/src/test/java/com/jauntsdn/rsocket/integration/IntegrationTest.java
+++ b/rsocket-transport-netty/src/test/java/com/jauntsdn/rsocket/integration/IntegrationTest.java
@@ -27,9 +27,10 @@ import com.jauntsdn.rsocket.AbstractRSocket;
 import com.jauntsdn.rsocket.Payload;
 import com.jauntsdn.rsocket.RSocket;
 import com.jauntsdn.rsocket.RSocketFactory;
+import com.jauntsdn.rsocket.plugins.ClientAcceptorInterceptor;
 import com.jauntsdn.rsocket.plugins.DuplexConnectionInterceptor;
 import com.jauntsdn.rsocket.plugins.RSocketInterceptor;
-import com.jauntsdn.rsocket.plugins.SocketAcceptorInterceptor;
+import com.jauntsdn.rsocket.plugins.ServerAcceptorInterceptor;
 import com.jauntsdn.rsocket.test.TestSubscriber;
 import com.jauntsdn.rsocket.transport.netty.client.TcpClientTransport;
 import com.jauntsdn.rsocket.transport.netty.server.CloseableChannel;
@@ -51,8 +52,8 @@ public class IntegrationTest {
 
   private static final RSocketInterceptor requesterPlugin;
   private static final RSocketInterceptor responderPlugin;
-  private static final SocketAcceptorInterceptor clientAcceptorPlugin;
-  private static final SocketAcceptorInterceptor serverAcceptorPlugin;
+  private static final ClientAcceptorInterceptor clientAcceptorPlugin;
+  private static final ServerAcceptorInterceptor serverAcceptorPlugin;
   private static final DuplexConnectionInterceptor connectionPlugin;
   public static volatile boolean calledRequester = false;
   public static volatile boolean calledResponder = false;

--- a/rsocket-transport-netty/src/test/java/com/jauntsdn/rsocket/transport/netty/SetupRejectionTest.java
+++ b/rsocket-transport-netty/src/test/java/com/jauntsdn/rsocket/transport/netty/SetupRejectionTest.java
@@ -3,7 +3,7 @@ package com.jauntsdn.rsocket.transport.netty;
 import com.jauntsdn.rsocket.ConnectionSetupPayload;
 import com.jauntsdn.rsocket.RSocket;
 import com.jauntsdn.rsocket.RSocketFactory;
-import com.jauntsdn.rsocket.SocketAcceptor;
+import com.jauntsdn.rsocket.ServerSocketAcceptor;
 import com.jauntsdn.rsocket.exceptions.RejectedSetupException;
 import com.jauntsdn.rsocket.transport.ClientTransport;
 import com.jauntsdn.rsocket.transport.ServerTransport;
@@ -100,7 +100,7 @@ public class SetupRejectionTest {
     }
   }
 
-  private static class RejectingAcceptor implements SocketAcceptor {
+  private static class RejectingAcceptor implements ServerSocketAcceptor {
     private final String msg;
     private final EmitterProcessor<RSocket> requesters = EmitterProcessor.create();
 


### PR DESCRIPTION
Change client acceptor signature to (setup,senderRSocket) -> handlerRSocket from (setup,senderRSocket) -> Mono<handlerRSocket> as client cannot reject requests, and async handlers on both client and server may lead to deadlock.