### PR TITLE
ConnectionSetupPayload cleanup

### DIFF
--- a/rsocket-core/src/main/java/com/jauntsdn/rsocket/ConnectionSetupPayload.java
+++ b/rsocket-core/src/main/java/com/jauntsdn/rsocket/ConnectionSetupPayload.java
@@ -19,14 +19,13 @@ package com.jauntsdn.rsocket;
 import com.jauntsdn.rsocket.frame.FrameHeaderFlyweight;
 import com.jauntsdn.rsocket.frame.SetupFrameFlyweight;
 import io.netty.buffer.ByteBuf;
-import io.netty.util.AbstractReferenceCounted;
 import javax.annotation.Nullable;
 
 /**
  * Exposed to server for determination of ResponderRSocket based on mime types and SETUP
  * metadata/data
  */
-public abstract class ConnectionSetupPayload extends AbstractReferenceCounted implements Payload {
+public abstract class ConnectionSetupPayload implements Payload {
 
   public static ConnectionSetupPayload create(final ByteBuf setupFrame) {
     return new DefaultConnectionSetupPayload(setupFrame);
@@ -50,16 +49,10 @@ public abstract class ConnectionSetupPayload extends AbstractReferenceCounted im
   public abstract ByteBuf resumeToken();
 
   @Override
-  public ConnectionSetupPayload retain() {
-    super.retain();
-    return this;
-  }
+  public abstract ConnectionSetupPayload retain();
 
   @Override
-  public ConnectionSetupPayload retain(int increment) {
-    super.retain(increment);
-    return this;
-  }
+  public abstract ConnectionSetupPayload retain(int increment);
 
   @Override
   public abstract ConnectionSetupPayload touch();
@@ -120,6 +113,18 @@ public abstract class ConnectionSetupPayload extends AbstractReferenceCounted im
     }
 
     @Override
+    public ConnectionSetupPayload retain() {
+      setupFrame.retain();
+      return this;
+    }
+
+    @Override
+    public ConnectionSetupPayload retain(int increment) {
+      setupFrame.retain(increment);
+      return this;
+    }
+
+    @Override
     public ConnectionSetupPayload touch() {
       setupFrame.touch();
       return this;
@@ -132,8 +137,18 @@ public abstract class ConnectionSetupPayload extends AbstractReferenceCounted im
     }
 
     @Override
-    protected void deallocate() {
-      setupFrame.release();
+    public boolean release() {
+      return setupFrame.release();
+    }
+
+    @Override
+    public boolean release(int decrement) {
+      return setupFrame.release(decrement);
+    }
+
+    @Override
+    public int refCnt() {
+      return setupFrame.refCnt();
     }
 
     @Override

--- a/rsocket-core/src/main/java/com/jauntsdn/rsocket/frame/SetupFrameFlyweight.java
+++ b/rsocket-core/src/main/java/com/jauntsdn/rsocket/frame/SetupFrameFlyweight.java
@@ -55,8 +55,9 @@ public class SetupFrameFlyweight {
       final String dataMimeType,
       final Payload setupPayload) {
 
-    ByteBuf metadata = setupPayload.hasMetadata() ? setupPayload.sliceMetadata() : null;
-    ByteBuf data = setupPayload.sliceData();
+    ByteBuf metadata =
+        setupPayload.hasMetadata() ? writeBytes(allocator, setupPayload.metadata()) : null;
+    ByteBuf data = writeBytes(allocator, setupPayload.data());
 
     int flags = 0;
 
@@ -221,5 +222,18 @@ public class SetupFrameFlyweight {
     byte length = byteBuf.skipBytes(skip).readByte();
     length = byteBuf.skipBytes(length).readByte();
     byteBuf.skipBytes(length);
+  }
+
+  private static ByteBuf writeBytes(ByteBufAllocator allocator, ByteBuf byteBuf) {
+    int readableBytes = byteBuf.readableBytes();
+    if (readableBytes == 0) {
+      return Unpooled.EMPTY_BUFFER;
+    }
+    ByteBuf buffer = allocator.buffer(readableBytes);
+    byteBuf.markReaderIndex();
+    buffer.writeBytes(byteBuf);
+    byteBuf.resetReaderIndex();
+
+    return buffer;
   }
 }

--- a/rsocket-core/src/main/java/com/jauntsdn/rsocket/internal/ClientSetup.java
+++ b/rsocket-core/src/main/java/com/jauntsdn/rsocket/internal/ClientSetup.java
@@ -26,7 +26,6 @@ import com.jauntsdn.rsocket.resume.ResumableFramesStore;
 import com.jauntsdn.rsocket.resume.ResumeStrategy;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
 import java.time.Duration;
 import java.util.function.Supplier;
 import reactor.core.publisher.Mono;
@@ -36,8 +35,6 @@ public interface ClientSetup {
   DuplexConnection connection();
 
   KeepAliveHandler keepAliveHandler();
-
-  ByteBuf resumeToken();
 
   class DefaultClientSetup implements ClientSetup {
     private final DuplexConnection connection;
@@ -55,15 +52,9 @@ public interface ClientSetup {
     public KeepAliveHandler keepAliveHandler() {
       return new DefaultKeepAliveHandler(connection);
     }
-
-    @Override
-    public ByteBuf resumeToken() {
-      return Unpooled.EMPTY_BUFFER;
-    }
   }
 
   class ResumableClientSetup implements ClientSetup {
-    private final ByteBuf resumeToken;
     private final ResumableDuplexConnection duplexConnection;
     private final ResumableKeepAliveHandler keepAliveHandler;
 
@@ -91,7 +82,6 @@ public interface ClientSetup {
               .resumeToken(resumeToken);
       this.duplexConnection = rSocketSession.resumableConnection();
       this.keepAliveHandler = new ResumableKeepAliveHandler(duplexConnection);
-      this.resumeToken = resumeToken;
     }
 
     @Override
@@ -102,11 +92,6 @@ public interface ClientSetup {
     @Override
     public KeepAliveHandler keepAliveHandler() {
       return keepAliveHandler;
-    }
-
-    @Override
-    public ByteBuf resumeToken() {
-      return resumeToken;
     }
   }
 }


### PR DESCRIPTION
SetupFrameFlyweight copies setupPayload data & metadata into frame instead of slicing

ConnectionSetupPayload resume token is just a ByteBuf instead of Supplier<ByteBuf>

ConnectionSetupPayload retain/release is applied to underlying ByteBuf